### PR TITLE
Remove private namespace substitution character ~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 config/mwear.yaml
 *.swp
 *.pyc
+
+*.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN python3 -m pip install "warble==1.2.6" "metawear==0.7.0" "pymetawear==0.12.0" numpy-quaternion
 
-COPY ./metawear_ros/ /ros_ws/src/metawear_ros
+COPY ./ /ros_ws/src/metawear_ros
 
 # RUN mkdir -p /ros_ws/src/ && cd /ros_ws/src/ && git clone -b ros2 https://github.com/Gabry993/metawear_ros.git
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM ros:foxy
-MAINTAINER Jerome Guzzi "jerome@idsia.ch"
+FROM ros:galactic
+MAINTAINER Gabriele Abbate "gabriele.abbate@supsi.ch"
 
 RUN apt-get update && apt-get install -y \
     locales \
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     libbluetooth-dev \
     libboost-all-dev \
     libudev-dev \
+    python3-pykdl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8
@@ -18,9 +19,11 @@ SHELL ["/bin/bash", "-c"]
 
 # COPY ./version.txt ./version.txt
 
-RUN python3 -m pip install metawear pymetawear numpy-quaternion
+RUN python3 -m pip install "warble==1.2.6" "metawear==0.7.0" "pymetawear==0.12.0" numpy-quaternion
 
-COPY ./ /ros_ws/src/metawear_ros
+COPY ./metawear_ros/ /ros_ws/src/metawear_ros
+
+# RUN mkdir -p /ros_ws/src/ && cd /ros_ws/src/ && git clone -b ros2 https://github.com/Gabry993/metawear_ros.git
 
 RUN cd /ros_ws && \
   source /ros_entrypoint.sh && \

--- a/docker/_main.launch
+++ b/docker/_main.launch
@@ -1,23 +1,26 @@
 <launch>
-  <arg name="address" default="c1:9d:0e:3c:f6:7e"/>
+  <!-- <arg name="address" default="df:e6:50:cd:84:85"/>--> <!-- meta 3-->
+  <arg name="address" default="c1:9d:0e:3c:f6:7e"/> <!-- meta 1-->
+  <!--<arg name="address" default="f1:34:82:44:19:d7"/>--> <!-- meta 4-->
   <arg name="interface" default="hci0"/>
   <arg name="persistent_config" default="true"/>
-   <node pkg="metawear_ros" exec="metawear_node">>
-     <param name="address" value="$(var address)"/>
-     <param name="interface" value="$(var interface)"/>
-     <param name="republish_button" value="false"/>
-     <param name="pause_streaming_if_no_subscribers" value="false"/>
-     <param name="publish_rate" value="25"/>
-     <param name="frame_id" value="mwear"/>
-     <param name="mimic_myo_frame" value="true"/>
-     <param name="publish_rate" value=""/>
-     <param name="save_config" value="$(var persistent_config)"/>
-     <param name="load_config" value="$(var persistent_config)"/>
-     <param name="led_color">
-       <param name="r" value="0.0"/>
-       <param name="g" value="1.0"/>
-       <param name="b" value="1.0"/>
-       <param name="a" value="1.0"/>
-     </param>
-  </node>
+	   <node pkg="metawear_ros" exec="metawear_node" namespace="$(env USER_NAME)">
+	     <param name="address" value="$(var address)"/>
+	     <param name="interface" value="$(var interface)"/>
+	     <param name="republish_button" value="false"/>
+	     <param name="give_button_feedback" value="true"/>
+	     <param name="pause_streaming_if_no_subscribers" value="false"/>
+	     <param name="publish_rate" value="25"/>
+	     <param name="frame_id" value="mwear"/>
+	     <param name="mimic_myo_frame" value="false"/>
+	     <param name="publish_rate" value=""/>
+	     <param name="save_config" value="$(var persistent_config)"/>
+	     <param name="load_config" value="$(var persistent_config)"/>
+	     <param name="led_color">
+	       <param name="r" value="0.0"/>
+	       <param name="g" value="1.0"/>
+	       <param name="b" value="1.0"/>
+	       <param name="a" value="1.0"/>
+	     </param>
+	  </node>
 </launch>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,13 +1,14 @@
 version: '3'
 services:
   metawear_ros:
-    image: jeguzzi/metawear_ros:foxy
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
+    image: gabry993/metawear_ros:galactic
     network_mode: host
     privileged: true
     command: ros2 launch metawear_ros _main.launch
     volumes:
       - ./logs:/root/.ros/log:rw
       - ./_main.launch:/ros_ws/install/share/metawear_ros/launch/_main.launch:ro
+      - ./profile.xml:/profile.xml
+    environment:
+      - "FASTRTPS_DEFAULT_PROFILES_FILE=/profile.xml"
+      - "USER_NAME=$USER_NAME"

--- a/metawear_ros/metawear_ros.py
+++ b/metawear_ros/metawear_ros.py
@@ -181,6 +181,12 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
             history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
             durability=rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL,
         )
+        default_qos = rclpy.qos.QoSProfile(
+            depth=10,
+            history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
+            durability=rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=rclpy.qos.QoSReliabilityPolicy.RELIABLE
+        )
         self.pub_rotation = self.create_publisher(
             geometry_msgs.msg.QuaternionStamped, rotation_topic, stream_qos
         )
@@ -210,7 +216,7 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
         self.calib_data: Dict[str, List[int]] = {}
         # DONE(Jerome): add appropriate qos for queue_size=10 and latch=(not self.republish_button)
         self.pub_button = self.create_publisher(
-            std_msgs.msg.Bool, button_topic, stream_qos if self.republish_button else rclpy.qos.QoSProfile()
+            std_msgs.msg.Bool, button_topic, stream_qos if self.republish_button else default_qos
         )
         self.button_topic = self.track_topic(button_topic)
         # DONE(Jerome): add appropriate qos for queue_size=10 and latch=True

--- a/metawear_ros/metawear_ros.py
+++ b/metawear_ros/metawear_ros.py
@@ -132,7 +132,7 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
         accel_topic = self.declare_parameter("accel_topic", "accel").value
         gyro_topic = self.declare_parameter("gyro_topic", "gyro").value
         calib_state_topic = self.declare_parameter(
-            "calib_state_topic", "~/calibration_state"
+            "calib_state_topic", "calibration_state"
         ).value
         button_topic = self.declare_parameter("button_topic", "button").value
         battery_topic = self.declare_parameter("battery_topic", "battery_state").value
@@ -262,10 +262,10 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
             std_msgs.msg.ColorRGBA, led_topic, self.led_cb, cmd_qos
         )
         self.sub_exec_timer = self.create_subscription(
-            std_msgs.msg.UInt8, "~/exec_timer", self.exec_timer_cb, cmd_qos
+            std_msgs.msg.UInt8, "exec_timer", self.exec_timer_cb, cmd_qos
         )
         self.sub_reset = self.create_subscription(
-            std_msgs.msg.Bool, "~/reset_board", self.reset_board_cb, cmd_qos
+            std_msgs.msg.Bool, "reset_board", self.reset_board_cb, cmd_qos
         )
 
         # DONE(Jerome): Do we really need this partial TF trasform? -> No

--- a/metawear_ros/metawear_ros.py
+++ b/metawear_ros/metawear_ros.py
@@ -111,7 +111,7 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
         self.should_save_config: bool = self.declare_parameter("save_config", True).value
         self.load_config()
 
-        rotation_topic = self.declare_parameter("rotation_topic", "~/rotation").value
+        rotation_topic = self.declare_parameter("rotation_topic", "rotation").value
 
         # ### Experimental ####
         # joint_states_topic = self.declare_parameter('joint_states_topic', 'joint_states')
@@ -123,27 +123,27 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
         # DONE(Jerome): Is this uses/usefull? -> maybe
         self.yaw_origin = 0.0
         self.srv_set_yaw_origin = self.create_service(
-            std_srvs.srv.Empty, "~/set_yaw_origin", self.set_yaw_origin
+            std_srvs.srv.Empty, "set_yaw_origin", self.set_yaw_origin
         )
         ######################
 
         # DONE(Jerome): do I need the tilde? -> yes but it should be ~/
 
-        accel_topic = self.declare_parameter("accel_topic", "~/accel").value
-        gyro_topic = self.declare_parameter("gyro_topic", "~/gyro").value
+        accel_topic = self.declare_parameter("accel_topic", "accel").value
+        gyro_topic = self.declare_parameter("gyro_topic", "gyro").value
         calib_state_topic = self.declare_parameter(
             "calib_state_topic", "~/calibration_state"
         ).value
-        button_topic = self.declare_parameter("button_topic", "~/button").value
-        battery_topic = self.declare_parameter("battery_topic", "~/battery_state").value
+        button_topic = self.declare_parameter("button_topic", "button").value
+        battery_topic = self.declare_parameter("battery_topic", "battery_state").value
         temperature_topic = self.declare_parameter(
-            "temperature_topic", "~/temperature"
+            "temperature_topic", "temperature"
         ).value
         illuminance_topic = self.declare_parameter(
-            "illuminance_topic", "~/illuminance"
+            "illuminance_topic", "illuminance"
         ).value
         # air_pressure_topic = self.declare_parameter('air_pressure_topic', 'air_pressure')
-        altitude_topic = self.declare_parameter("altitude_topic", "~/altitude").value
+        altitude_topic = self.declare_parameter("altitude_topic", "altitude").value
         self.give_button_feedback = self.declare_parameter(
             "give_button_feedback", False
         ).value
@@ -151,12 +151,12 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
         self.button_val = std_msgs.msg.Bool(data=False)
 
         vibration_topic = self.declare_parameter(
-            "vibration_topic", "~/vibration2"
+            "vibration_topic", "vibration2"
         ).value
         vibration_pattern_topic = self.declare_parameter(
-            "vibration_pattern_topic", "~/vibration_pattern"
+            "vibration_pattern_topic", "vibration_pattern"
         ).value
-        led_topic = self.declare_parameter("led_topic", "~/led").value
+        led_topic = self.declare_parameter("led_topic", "led").value
         # DONE(Jerome): can I have map as param value?
         # -> I can but I have to define them one by one
         led_color = {}

--- a/metawear_ros/metawear_ros.py
+++ b/metawear_ros/metawear_ros.py
@@ -175,6 +175,7 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
             depth=10,
             history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
             durability=rclpy.qos.QoSDurabilityPolicy.VOLATILE,
+            reliability=rclpy.qos.QoSReliabilityPolicy.BEST_EFFORT
         )
         state_qos = rclpy.qos.QoSProfile(
             depth=1,

--- a/metawear_ros/metawear_ros.py
+++ b/metawear_ros/metawear_ros.py
@@ -210,7 +210,7 @@ class MetaWearRos(rclpy.node.Node):  # type: ignore
         self.calib_data: Dict[str, List[int]] = {}
         # DONE(Jerome): add appropriate qos for queue_size=10 and latch=(not self.republish_button)
         self.pub_button = self.create_publisher(
-            std_msgs.msg.Bool, button_topic, stream_qos if self.republish_button else state_qos
+            std_msgs.msg.Bool, button_topic, stream_qos if self.republish_button else rclpy.qos.QoSProfile()
         )
         self.button_topic = self.track_topic(button_topic)
         # DONE(Jerome): add appropriate qos for queue_size=10 and latch=True


### PR DESCRIPTION
This should remove the "metawear_ros" namespace added automatically to the node. The namespace can be specified in the launch file